### PR TITLE
Add console commands for index settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ return [
     "mappings" => [
         [
             'indexName' => 'blog',
+            'indexSettings' => [
+                'settings' => [
+                    'attributesForFaceting' => ['blogCategory'],
+                ],
+                'forwardToReplicas' => 'true',
+            ],
             'elementType' => \craft\elements\Entry::class,
             'criteria' => [
                 'section' => 'blog'

--- a/src/console/controllers/IndexController.php
+++ b/src/console/controllers/IndexController.php
@@ -122,7 +122,7 @@ class IndexController extends Controller
         Console::startProgress(
             $progress,
             $total,
-            Craft::t('scout', 'Setting index settings for {index}.', ['index' => $index ?: 'all mappings']),
+            Craft::t('scout', 'Setting index settings for {index}.', ['index' => $index ?: 'all mapped indices']),
             0.5
         );
 

--- a/src/console/controllers/IndexController.php
+++ b/src/console/controllers/IndexController.php
@@ -44,7 +44,7 @@ class IndexController extends Controller
      *
      * @return mixed
      */
-    public function actionFlush($index='')
+    public function actionFlush($index = '')
     {
         if ($this->confirm(Craft::t('scout', 'Are you sure you want to flush Scout?'))) {
             /* @var \rias\scout\models\AlgoliaIndex $mapping */
@@ -69,7 +69,7 @@ class IndexController extends Controller
      *
      * @return int
      */
-    public function actionImport($index='')
+    public function actionImport($index = '')
     {
         /* @var \rias\scout\models\AlgoliaIndex $mapping */
         foreach ($this->getMappings($index) as $mapping) {
@@ -112,7 +112,7 @@ class IndexController extends Controller
      *
      * @return mixed
      */
-    public function actionSetSettings($index='')
+    public function actionSetSettings($index = '')
     {
         /* @var \rias\scout\models\AlgoliaIndex $mapping */
         foreach ($this->getMappings($index) as $mapping) {
@@ -140,7 +140,7 @@ class IndexController extends Controller
      *
      * @return mixed
      */
-    public function actionDumpSettings($index='')
+    public function actionDumpSettings($index = '')
     {
         $dump = [];
 
@@ -160,7 +160,7 @@ class IndexController extends Controller
      *
      * @return array
      */
-    protected function getMappings($index='')
+    protected function getMappings($index = '')
     {
         $mappings = Scout::$plugin->scoutService->getMappings();
 

--- a/src/console/controllers/IndexController.php
+++ b/src/console/controllers/IndexController.php
@@ -142,14 +142,15 @@ class IndexController extends Controller
      */
     public function actionDumpSettings($index='')
     {
+        $dump = [];
+
         /* @var \rias\scout\models\AlgoliaIndex $mapping */
         foreach ($this->getMappings($index) as $mapping) {
             $index = Scout::$plugin->scoutService->getClient()->initIndex($mapping->indexName);
-            VarDumper::dump($index->getSettings());
+            $dump[$mapping->indexName] = $index->getSettings();
         }
 
-        // Everything went OK
-        return ExitCode::OK;
+        return VarDumper::dump($dump);
     }
 
     /**

--- a/src/console/controllers/IndexController.php
+++ b/src/console/controllers/IndexController.php
@@ -102,7 +102,7 @@ class IndexController extends Controller
     }
 
     /**
-     * Sets settings for one or all indices.
+     * Updates settings for one or all indices.
      *
      * @param string $index
      *
@@ -112,7 +112,7 @@ class IndexController extends Controller
      *
      * @return mixed
      */
-    public function actionSetSettings($index = '')
+    public function actionUpdateSettings($index = '')
     {
         /* @var \rias\scout\models\AlgoliaIndex $mapping */
         $mappings = $this->getMappings($index);
@@ -122,14 +122,14 @@ class IndexController extends Controller
         Console::startProgress(
             $progress,
             $total,
-            Craft::t('scout', 'Setting index settings for {index}.', ['index' => $index ?: 'all mapped indices']),
+            Craft::t('scout', 'Updating index settings for {index}.', ['index' => $index ?: 'all mapped indices']),
             0.5
         );
 
         foreach ($mappings as $mapping) {
             $index = Scout::$plugin->scoutService->getClient()->initIndex($mapping->indexName);
-            $settings = $mapping->indexSettings->settings ?? null;
-            $forwardToReplicas = $mapping->indexSettings ?? null;
+            $settings = $mapping->indexSettings['settings'] ?? null;
+            $forwardToReplicas = $mapping->indexSettings['forwardToReplicas'] ?? null;
 
             if ($settings) {
                 $index->setSettings($settings, $forwardToReplicas);

--- a/src/console/controllers/IndexController.php
+++ b/src/console/controllers/IndexController.php
@@ -104,7 +104,7 @@ class IndexController extends Controller
     /**
      * Sets settings for one or all indices.
      *
-     * @param  string $index
+     * @param string $index
      *
      * @throws Exception
      * @throws \AlgoliaSearch\AlgoliaException
@@ -132,7 +132,7 @@ class IndexController extends Controller
     /**
      * Dumps settings for one or all indices.
      *
-     * @param  string $index
+     * @param string $index
      *
      * @throws Exception
      * @throws \AlgoliaSearch\AlgoliaException

--- a/src/console/controllers/IndexController.php
+++ b/src/console/controllers/IndexController.php
@@ -115,14 +115,28 @@ class IndexController extends Controller
     public function actionSetSettings($index = '')
     {
         /* @var \rias\scout\models\AlgoliaIndex $mapping */
-        foreach ($this->getMappings($index) as $mapping) {
+        $mappings = $this->getMappings($index);
+        $total = count($mappings);
+
+        foreach ($mappings as $mapping) {
             $index = Scout::$plugin->scoutService->getClient()->initIndex($mapping->indexName);
             $settings = $mapping->indexSettings->settings ?? null;
             $forwardToReplicas = $mapping->indexSettings ?? null;
+            $progress = 0;
+
+            Console::startProgress(
+                $progress,
+                $total,
+                Craft::t('scout', 'Adding elements from index {index}.', ['index' => $mapping->indexName]),
+                0.5
+            );
 
             if ($settings) {
                 $index->setSettings($settings, $forwardToReplicas);
             }
+
+            Console::updateProgress($total, $total);
+            Console::endProgress();
         }
 
         // Everything went OK

--- a/src/console/controllers/IndexController.php
+++ b/src/console/controllers/IndexController.php
@@ -44,7 +44,7 @@ class IndexController extends Controller
      *
      * @return mixed
      */
-    public function actionFlush($index = '')
+    public function actionFlush($index='')
     {
         if ($this->confirm(Craft::t('scout', 'Are you sure you want to flush Scout?'))) {
             /* @var \rias\scout\models\AlgoliaIndex $mapping */
@@ -69,7 +69,7 @@ class IndexController extends Controller
      *
      * @return int
      */
-    public function actionImport($index = '')
+    public function actionImport($index='')
     {
         /* @var \rias\scout\models\AlgoliaIndex $mapping */
         foreach ($this->getMappings($index) as $mapping) {
@@ -160,7 +160,7 @@ class IndexController extends Controller
      *
      * @return array
      */
-    protected function getMappings($index = '')
+    protected function getMappings($index='')
     {
         $mappings = Scout::$plugin->scoutService->getMappings();
 

--- a/src/console/controllers/IndexController.php
+++ b/src/console/controllers/IndexController.php
@@ -130,7 +130,7 @@ class IndexController extends Controller
     }
 
     /**
-     * Gets settings for one or all indices.
+     * Dumps settings for one or all indices.
      *
      * @param  string $index
      *
@@ -140,12 +140,12 @@ class IndexController extends Controller
      *
      * @return mixed
      */
-    public function actionGetSettings($index='')
+    public function actionDumpSettings($index='')
     {
         /* @var \rias\scout\models\AlgoliaIndex $mapping */
         foreach ($this->getMappings($index) as $mapping) {
             $index = Scout::$plugin->scoutService->getClient()->initIndex($mapping->indexName);
-            VarDumper::dump($index->getSettings())
+            VarDumper::dump($index->getSettings());
         }
 
         // Everything went OK

--- a/src/console/controllers/IndexController.php
+++ b/src/console/controllers/IndexController.php
@@ -101,6 +101,34 @@ class IndexController extends Controller
     }
 
     /**
+     * Sets settings for one or all indices.
+     *
+     * @param  string $index
+     *
+     * @throws Exception
+     * @throws \AlgoliaSearch\AlgoliaException
+     * @throws \Exception
+     *
+     * @return mixed
+     */
+    public function actionSetSettings($index='')
+    {
+        /* @var \rias\scout\models\AlgoliaIndex $mapping */
+        foreach ($this->getMappings($index) as $mapping) {
+            $index = Scout::$plugin->scoutService->getClient()->initIndex($mapping->indexName);
+            $settings = $mapping->indexSettings->settings ?? null;
+            $forwardToReplicas = $mapping->indexSettings ?? null;
+
+            if ($settings) {
+                $index->setSettings($settings, $forwardToReplicas);
+            }
+        }
+
+        // Everything went OK
+        return ExitCode::OK;
+    }
+
+    /**
      * @param string $index
      *
      * @throws Exception

--- a/src/console/controllers/IndexController.php
+++ b/src/console/controllers/IndexController.php
@@ -19,6 +19,7 @@ use yii\console\Controller;
 use yii\console\Exception;
 use yii\console\ExitCode;
 use yii\helpers\Console;
+use yii\helpers\VarDumper;
 
 /**
  * Default Command.
@@ -122,6 +123,29 @@ class IndexController extends Controller
             if ($settings) {
                 $index->setSettings($settings, $forwardToReplicas);
             }
+        }
+
+        // Everything went OK
+        return ExitCode::OK;
+    }
+
+    /**
+     * Gets settings for one or all indices.
+     *
+     * @param  string $index
+     *
+     * @throws Exception
+     * @throws \AlgoliaSearch\AlgoliaException
+     * @throws \Exception
+     *
+     * @return mixed
+     */
+    public function actionGetSettings($index='')
+    {
+        /* @var \rias\scout\models\AlgoliaIndex $mapping */
+        foreach ($this->getMappings($index) as $mapping) {
+            $index = Scout::$plugin->scoutService->getClient()->initIndex($mapping->indexName);
+            VarDumper::dump($index->getSettings())
         }
 
         // Everything went OK

--- a/src/console/controllers/IndexController.php
+++ b/src/console/controllers/IndexController.php
@@ -117,25 +117,26 @@ class IndexController extends Controller
         /* @var \rias\scout\models\AlgoliaIndex $mapping */
         $mappings = $this->getMappings($index);
         $total = count($mappings);
+        $progress = 0;
+
+        Console::startProgress(
+            $progress,
+            $total,
+            Craft::t('scout', 'Setting index settings for {index}.', ['index' => $index ?: 'all mappings']),
+            0.5
+        );
 
         foreach ($mappings as $mapping) {
             $index = Scout::$plugin->scoutService->getClient()->initIndex($mapping->indexName);
             $settings = $mapping->indexSettings->settings ?? null;
             $forwardToReplicas = $mapping->indexSettings ?? null;
-            $progress = 0;
-
-            Console::startProgress(
-                $progress,
-                $total,
-                Craft::t('scout', 'Adding elements from index {index}.', ['index' => $mapping->indexName]),
-                0.5
-            );
 
             if ($settings) {
                 $index->setSettings($settings, $forwardToReplicas);
             }
 
-            Console::updateProgress($total, $total);
+            $progress++;
+            Console::updateProgress($progress, $total);
             Console::endProgress();
         }
 

--- a/src/models/AlgoliaIndex.php
+++ b/src/models/AlgoliaIndex.php
@@ -35,6 +35,9 @@ class AlgoliaIndex extends Model
     /* @var string */
     public $indexName;
 
+    /* @var array */
+    public $indexSettings = [];
+
     /* @var string */
     public $elementType;
 


### PR DESCRIPTION
Adds `scout/index/update-settings` and `scout/index/dump-settings`.

I wanted to have these settings sourced, and also needed the ability to `forwardToReplicas`, which you can't do via the Algolia admin, only the API.