### PR TITLE
Added the site ID for multi sites settings.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "rias/craft-scout",
+    "name": "jorgeanzola/craft-scout",
     "description": "Craft Scout provides a simple solution for adding full-text search to your entries. Scout will automatically keep your search indexes in sync with your entries.",
     "type": "craft-plugin",
     "version": "0.4.1",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jorgeanzola/craft-scout",
+    "name": "rias/craft-scout",
     "description": "Craft Scout provides a simple solution for adding full-text search to your entries. Scout will automatically keep your search indexes in sync with your entries.",
     "type": "craft-plugin",
     "version": "0.4.1",

--- a/src/models/AlgoliaIndex.php
+++ b/src/models/AlgoliaIndex.php
@@ -80,7 +80,7 @@ class AlgoliaIndex extends Model
 
         $data = $fractal->createData($resource)->toArray();
         // Make sure the objectID is set for Algolia
-		$data['objectID'] = $element->siteId . '_' . $element->id;
+		$data['objectID'] = $this->getSiteElementId($element);
 		// Include the site language in the record.
 		$data['siteLanguage'] = $element->site->language;
 
@@ -254,4 +254,9 @@ class AlgoliaIndex extends Model
 
         return $query;
     }
+
+    public function getSiteElementId(Element $element)
+	{
+		return $element->siteId . '_' . $element->id;
+	}
 }

--- a/src/models/AlgoliaIndex.php
+++ b/src/models/AlgoliaIndex.php
@@ -257,6 +257,6 @@ class AlgoliaIndex extends Model
 
     public function getSiteElementId(Element $element)
 	{
-		return $element->siteId . '_' . $element->id;
+		return $element->siteId.'_'.$element->id;
 	}
 }

--- a/src/models/AlgoliaIndex.php
+++ b/src/models/AlgoliaIndex.php
@@ -80,7 +80,9 @@ class AlgoliaIndex extends Model
 
         $data = $fractal->createData($resource)->toArray();
         // Make sure the objectID is set for Algolia
-        $data['objectID'] = $element->id;
+		$data['objectID'] = $element->siteId . '_' . $element->id;
+		// Include the site language in the record.
+		$data['siteLanguage'] = $element->site->language;
 
         return $data;
     }


### PR DESCRIPTION
In my multi-site setup, I found out that when saving an entry, only the last site's version of the entry will be indexed. 

i.e. Two sites (languages): English, Dutch. 
Editing the entry in English and saving will outcome with the Dutch version of the entry indexed in Algolia, as it's the last site saved on Craft.