### PR TITLE
add connect timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Within the mappings array, each index is represented by a configuration array.
 
 return [
     "sync" => true,
+    "connect_timeout" => 1,
     "application_id" => "algolia",
     "admin_api_key" => "algolia",
     "mappings" => [
@@ -64,6 +65,9 @@ return [
 
 ### The Sync option
 This config variable determines if Scout should keep your entries in sync automatically. Setting this to `false` disables all of Scout's event listeners.
+
+### Connect timeout
+This config variable determines the connect timeout in seconds to Algolia servers. You should only change this if you have a slow server. Standard is 1 second.
 
 ### Mapping configuration settings
 

--- a/src/config.php
+++ b/src/config.php
@@ -26,6 +26,8 @@
 return [
     // Whether Scout should automatically index and de-index your entries
     'sync' => true,
+    // Algolia connection timeout in seconds
+    'connect_timeout' => 1,
     // These can both be found in your Algolia Account:  https://www.algolia.com/api-keys
     'application_id' => 'algolia',
     'admin_api_key'  => 'algolia',

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -41,6 +41,9 @@ class Settings extends Model
     /* @var string */
     public $admin_api_key = '';
 
+    /* @var int */
+    public $connect_timeout = 1;
+
     // Public Methods
     // =========================================================================
 
@@ -50,9 +53,10 @@ class Settings extends Model
     public function rules()
     {
         return [
+            [['connect_timeout'], 'int'],
             [['sync'], 'boolean'],
             [['application_id', 'admin_api_key'], 'string'],
-            [['sync', 'application_id', 'admin_api_key'], 'required'],
+            [['sync', 'application_id', 'admin_api_key', 'connect_timeout'], 'required'],
         ];
     }
 }

--- a/src/services/ScoutService.php
+++ b/src/services/ScoutService.php
@@ -49,6 +49,7 @@ class ScoutService extends Component
     {
         if (is_null($this->client)) {
             $this->client = new Client($this->settings->application_id, $this->settings->admin_api_key);
+            $this->client->setConnectTimeout($this->settings->connect_timeout);
         }
 
         return $this->client;


### PR DESCRIPTION
For slow networks one may need to adjust the connect timeout which defaults to one second. This PR  exposes that variable and lets you define whatever timeout you need.