### PR TITLE
cast site ids to int as craft/yii returns int as string

### DIFF
--- a/src/models/AlgoliaIndex.php
+++ b/src/models/AlgoliaIndex.php
@@ -62,7 +62,7 @@ class AlgoliaIndex extends Model
             return false;
         }
 
-        if (isset($this->criteria['siteId']) && $element->site->id !== $this->criteria['siteId']) {
+        if (isset($this->criteria['siteId']) && (int)$element->site->id !== (int)$this->criteria['siteId']) {
             return false;
         }
 


### PR DESCRIPTION
This PR casts both siteId from criteria and craft to int before comparing so it doesn't fail if one is int and the other is string.