### PR TITLE
Fix Yii validator name: “int” —> “integer”

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -53,7 +53,7 @@ class Settings extends Model
     public function rules()
     {
         return [
-            [['connect_timeout'], 'int'],
+            [['connect_timeout'], 'integer'],
             [['sync'], 'boolean'],
             [['application_id', 'admin_api_key'], 'string'],
             [['sync', 'application_id', 'admin_api_key', 'connect_timeout'], 'required'],


### PR DESCRIPTION
Yii 2 expects the validator to be called “integer” rather than “int”. This was causing an error when importing from a Schematic schema.yml file that included Scout plugin settings.

See: https://www.yiiframework.com/doc/guide/2.0/en/tutorial-core-validators#integer

Stack trace:
```bash
php ./craft schematic/import
Importing plugins
- Installing plugin amazon-ses
- Installing plugin aws-s3
- Installing plugin cp-field-inspect
- Installing plugin element-api
- Installing plugin redactor
- Installing plugin schematic
- Installing plugin scout
Exception 'ReflectionException' with message 'Class int does not exist'

in /srv/app/myproject/htdocs/vendor/yiisoft/yii2/di/Container.php:428

Stack trace:
#0 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/di/Container.php(428): ReflectionClass->__construct('int')
#1 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/di/Container.php(364): yii\di\Container->getDependencies('int')
#2 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/di/Container.php(156): yii\di\Container->build('int', Array, Array)
#3 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/BaseYii.php(349): yii\di\Container->get('int', Array, Array)
#4 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/validators/Validator.php(226): yii\BaseYii::createObject(Array)
#5 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/base/Model.php(458): yii\validators\Validator::createValidator('int', Object(rias\scout\models\Settings), Array, Array)
#6 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/base/Model.php(420): yii\base\Model->createValidators()
#7 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/base/Model.php(189): yii\base\Model->getValidators()
#8 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/base/Model.php(354): yii\base\Model->scenarios()
#9 /srv/app/myproject/htdocs/vendor/craftcms/cms/src/services/Plugins.php(585): yii\base\Model->validate()
#10 /srv/app/myproject/htdocs/vendor/nerds-and-company/schematic/src/Mappers/PluginMapper.php(114): craft\services\Plugins->savePluginSettings(Object(rias\scout\Scout), Array)
#11 /srv/app/myproject/htdocs/vendor/nerds-and-company/schematic/src/Mappers/PluginMapper.php(74): NerdsAndCompany\Schematic\Mappers\PluginMapper->savePlugin('scout', Array, Array)
#12 /srv/app/myproject/htdocs/vendor/nerds-and-company/schematic/src/Controllers/ImportController.php(88): NerdsAndCompany\Schematic\Mappers\PluginMapper->import(Array, Array)
#13 /srv/app/myproject/htdocs/vendor/nerds-and-company/schematic/src/Controllers/ImportController.php(49): NerdsAndCompany\Schematic\Controllers\ImportController->importFromYaml(Array)
#14 [internal function]: NerdsAndCompany\Schematic\Controllers\ImportController->actionIndex()
#15 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/base/InlineAction.php(57): call_user_func_array(Array, Array)
#16 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/base/Controller.php(157): yii\base\InlineAction->runWithParams(Array)
#17 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/console/Controller.php(148): yii\base\Controller->runAction('', Array)
#18 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/base/Module.php(528): yii\console\Controller->runAction('', Array)
#19 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/console/Application.php(180): yii\base\Module->runAction('schematic/impor...', Array)
#20 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/console/Application.php(147): yii\console\Application->runAction('schematic/impor...', Array)
#21 /srv/app/myproject/htdocs/vendor/yiisoft/yii2/base/Application.php(386): yii\console\Application->handleRequest(Object(craft\console\Request))
#22 /srv/app/myproject/htdocs/craft(22): yii\base\Application->run()
#23 {main}
```
