### PR TITLE
Disabling an entry should deindex it

### DIFF
--- a/src/models/AlgoliaIndex.php
+++ b/src/models/AlgoliaIndex.php
@@ -85,7 +85,7 @@ class AlgoliaIndex extends Model
             return false;
         }
 
-        return $this->getElementQuery($element)->count();
+        return $this->getElementQuery($element)->count() == 0;
     }
 
     /**


### PR DESCRIPTION
If the query returns results then elements can't be deindexed