### PR TITLE
Add Twig variables for Algolia settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.1.4 - 2019-04-10
+### Added
+- `search_api_key` setting to model
+- Twig variables for accessing Algolia settings in front end templates
+
+### Changed
+- Normalised the mixture of quotes in the config example documentation
+
 ## 1.1.3 - 2019-02-27
 - Fixed a regression by the previous release when deleting elements would not deIndex them.
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ Within the mappings array, each index is represented by a configuration array.
 <?php
 
 return [
-    "sync" => true,
-    "connect_timeout" => 1,
-    "application_id" => "algolia",
-    "admin_api_key" => "algolia",
-    "mappings" => [
+    'sync' => true,
+    'connect_timeout' => 1,
+    'application_id' => 'algolia',
+    'admin_api_key' => 'algolia',
+    'search_api_key' => 'algolia', // optional
+    'mappings' => [
         [
             'indexName' => 'blog',
             'indexSettings' => [
@@ -204,6 +205,15 @@ Array items are array indexes returned from the transformer.
 ```
 
 *Important* - distinctId (available after indexing) must be set up as an attribute for faceting for deletion of objects to work when using splitElementIndex.
+
+## Twig variables
+You can access the Algolia settings set in your config file through the following Twig variables.
+
+```twig
+{{ craft.scout.algoliaApplicationId }}
+{{ craft.scout.algoliaAdminApiKey }}
+{{ craft.scout.algoliaSearchApiKey }}
+```
 
 ## Console commands
 Scout provides two easy console commands for managing your indices.

--- a/src/Scout.php
+++ b/src/Scout.php
@@ -23,8 +23,10 @@ use craft\elements\MatrixBlock;
 use craft\elements\Tag;
 use craft\elements\User;
 use craft\events\ModelEvent;
+use craft\web\twig\variables\CraftVariable;
 use rias\scout\models\Settings;
 use rias\scout\services\ScoutService as ScoutServiceService;
+use rias\scout\variables\ScoutVariable;
 use yii\base\Event;
 
 /**
@@ -61,6 +63,17 @@ class Scout extends Plugin
         if ($request->getIsConsoleRequest()) {
             $this->controllerNamespace = 'rias\scout\console\controllers\scout';
         }
+
+        // Register our variables
+        Event::on(
+	        CraftVariable::class,
+	        CraftVariable::EVENT_INIT,
+	        function (Event $event) {
+		        /** @var CraftVariable $variable */
+		        $variable = $event->sender;
+		        $variable->set('scout', ScoutVariable::class);
+	        }
+        );
 
         /*
          * Add or update an element to the index

--- a/src/config.php
+++ b/src/config.php
@@ -28,9 +28,10 @@ return [
     'sync' => true,
     // Algolia connection timeout in seconds
     'connect_timeout' => 1,
-    // These can both be found in your Algolia Account:  https://www.algolia.com/api-keys
+    // These can be found in your Algolia Account: https://www.algolia.com/api-keys
     'application_id' => 'algolia',
     'admin_api_key'  => 'algolia',
+    'search_api_key' => 'algolia', //optional
     'mappings'       => [
 
     ],

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -41,6 +41,9 @@ class Settings extends Model
     /* @var string */
     public $admin_api_key = '';
 
+    /* @var string */
+    public $search_api_key = '';
+
     /* @var int */
     public $connect_timeout = 1;
 
@@ -55,7 +58,7 @@ class Settings extends Model
         return [
             [['connect_timeout'], 'integer'],
             [['sync'], 'boolean'],
-            [['application_id', 'admin_api_key'], 'string'],
+            [['application_id', 'admin_api_key', 'search_api_key'], 'string'],
             [['sync', 'application_id', 'admin_api_key', 'connect_timeout'], 'required'],
         ];
     }

--- a/src/services/ScoutService.php
+++ b/src/services/ScoutService.php
@@ -41,6 +41,36 @@ class ScoutService extends Component
     }
 
     /**
+     * Return the Algolia application ID defined in config/scout.php.
+     *
+     * @return string
+     */
+    public function getAlgoliaApplicationId() : string
+    {
+        return $this->settings->application_id;
+    }
+
+    /**
+     * Return the Algolia admin API key defined in config/scout.php.
+     *
+     * @return string
+     */
+    public function getAlgoliaAdminApiKey() : string
+    {
+        return $this->settings->admin_api_key;
+    }
+
+    /**
+     * Return the Algolia admin API key defined in config/scout.php.
+     *
+     * @return string
+     */
+    public function getAlgoliaSearchApiKey() : string
+    {
+        return $this->settings->search_api_key;
+    }
+
+    /**
      * @throws \Exception
      *
      * @return Client

--- a/src/variables/ScoutVariable.php
+++ b/src/variables/ScoutVariable.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Scout plugin for Craft CMS 3.x.
+ *
+ * Craft Scout provides a simple solution for adding full-text search to your entries. Scout will automatically keep your search indexes in sync with your entries.
+ *
+ * @link      https://rias.be
+ *
+ * @copyright Copyright (c) 2017 Rias
+ */
+
+namespace rias\scout\variables;
+
+use rias\scout\Scout;
+
+/**
+ * @author    Rias
+ *
+ * @since     1.1.4
+ */
+class ScoutVariable
+{
+	// Public Methods
+	// =========================================================================
+
+	/**
+	 * Returns the configured Algolia Application ID if set.
+	 *
+	 * @return string
+	 */
+	public function algoliaApplicationId() : string
+	{
+	    return Scout::$plugin->scoutService->getAlgoliaApplicationId();
+	}
+
+	/**
+	 * Returns the configured Algolia Admin API key if set.
+	 *
+	 * @return string
+	 */
+	public function algoliaAdminApiKey() : string
+	{
+	    return Scout::$plugin->scoutService->getAlgoliaAdminApiKey();
+	}
+
+	/**
+	 * Returns the configured Algolia search API key if set.
+	 *
+	 * @return string
+	 */
+	public function algoliaSearchApiKey() : string
+	{
+	    return Scout::$plugin->scoutService->getAlgoliaSearchApiKey();
+	}
+}


### PR DESCRIPTION
@Rias500 

I've implemented the Twig variables in this PR. I've also made a couple of additions, which I hope you will be OK with.

* Added a `search_api_key` setting to the model. I'm aware the plugin doesn't use this in it's operations, but from a front end perspective, it would be nice for Scout to have a setting for it, as for certain queries/operations you don't need to use the Admin key.

* Fixed up the inconsistent usage of quotes in the config example in the README.md

Please let me know if this is OK!

Many thanks!