### PR TITLE
Refactor null check for getClient service

### DIFF
--- a/src/services/ScoutService.php
+++ b/src/services/ScoutService.php
@@ -61,7 +61,7 @@ class ScoutService extends Component
     }
 
     /**
-     * Return the Algolia admin API key defined in config/scout.php.
+     * Return the Algolia search API key defined in config/scout.php.
      *
      * @return string
      */
@@ -77,7 +77,7 @@ class ScoutService extends Component
      */
     public function getClient()
     {
-        if (is_null($this->client)) {
+        if ($this->client !== null) {
             $this->client = new Client($this->settings->application_id, $this->settings->admin_api_key);
             $this->client->setConnectTimeout($this->settings->connect_timeout);
         }


### PR DESCRIPTION
Also another minor thing but you can avoid using the `is_null` function in favour of `$this->$client === null` or `$this->$client !== null`. While probably not humanly noticeable, it is faster execution wise than the function variant, because of the function call overhead.